### PR TITLE
Fix wrong mime type for jpg file in Select.elm

### DIFF
--- a/src/File/Select.elm
+++ b/src/File/Select.elm
@@ -88,7 +88,7 @@ you could say:
 
     requestImages : Cmd Msg
     requestImages =
-      Select.files ["image/png","image/jpg"] ImagesLoaded
+      Select.files ["image/png","image/jpeg"] ImagesLoaded
 
 In this case, we only want PNG and JPG files.
 


### PR DESCRIPTION
There is no mime type "image/jpg", for .jpg file it should be "image/jpeg". As it said in link below.

[Is the MIME type 'image/jpg' the same as 'image/jpeg'?](https://stackoverflow.com/questions/33692835/is-the-mime-type-image-jpg-the-same-as-image-jpeg)